### PR TITLE
Simplify update rate slider

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -403,34 +403,13 @@ function autobuyUpgrades(layer){
 		if (isPlainObject(tmp[layer].upgrades[id]) && (layers[layer].upgrades[id].canAfford === undefined || layers[layer].upgrades[id].canAfford() === true))
 			buyUpg(layer, id) 
 }
-var m = 50
-var slider = document.getElementById("myRange");
-var output = document.getElementById("demo");
 setInterval(function() {
+	if (!player || player.tab != "options-tab") return
 	slider = document.getElementById("myRange")
 	output = document.getElementById("demo")
-	if (slider) player.ms = Number(slider.value)
-	if (output) output.innerHTML = player.ms
-	if (player) {
-		m=player.ms
-		if (player.tab == "options-tab") player.options=true
-		else player.options=false
-		if (!player.options) {
-			check()
-		}
-	}
-},1)
-function check() {
-    if (player) {
-	if(!player.options) {
-       window.setTimeout(check, 30);
-    } else {
-		if (slider) {
-			slider.value = player.up
-		}
-    }
-}
-}
+	if (slider.value != player.ms) slider.value = player.ms
+	if (output.innerHTML != "" + player.ms) output.innerHTML = player.ms
+},10)
 function gameLoop() {
 	if (player===undefined||tmp===undefined) return;
 	if (ticking) return;
@@ -551,8 +530,10 @@ var interval
 var tickWait = 0
 var tickWaitStart = 0
 function input () {
-	player.up = player.ms
-    clearInterval(interval)
+	value = document.getElementById("myRange").value
+	document.getElementById("demo").innerHTML = value
+	player.ms = Number(value)
+	clearInterval(interval)
 	startInterval()
 }
 function startInterval() {

--- a/js/mod.js
+++ b/js/mod.js
@@ -193,7 +193,6 @@ function addedPlayerData() { return {
     infectivity: false,
     ms: 50,
     options:false,
-    up:50,
 }}
 var shiftDown = false
 

--- a/js/technical/layerSupport.js
+++ b/js/technical/layerSupport.js
@@ -285,7 +285,7 @@ addLayer("options-tab", {
         "options-tab",
         ["raw-html", function() { return `
         <div class="slidecontainer">
-        <p>Update Rate: <span id="demo"></span>ms</p>
+        <p>Update Rate: <span id="demo">50</span>ms</p>
         <input type="range" min="33" max="200" value="50" class="slider" id="myRange" onchange="input()" oninput = "input()">
         </div>
         `


### PR DESCRIPTION
The `check` function keeps getting called more and more for no reason (until the player opens the options), completely tanking the game's fps as the actual game loop had trouble getting scheduled.

We can just:
* Rely on `input()` to update `player.ms` as well as the update rate display.
* Remove `player.up`, as we don't really need to duplicate the information.
* Update the slider and display values only in the interval, which will actually only run when the option tab is opened.